### PR TITLE
Fix RVVI-Text vector register format specifier

### DIFF
--- a/RVVI-TEXT/README.md
+++ b/RVVI-TEXT/README.md
@@ -65,7 +65,7 @@ RET     0x%h 0x%h                 // retirement event     <pc> <instBin>
 TRAP    0x%h 0x%h                 // trap event           <pc> <instBin>
 X       %d   0x%h                 // GPR change           <register> <value>
 F       %d   0x%h                 // FPR change           <register> <value>
-V       0x%h 0x%h                 // VR change            <register> <value>
+V       %d   0x%h                 // VR change            <register> <value>
 C       0x%h 0x%h                 // CSR change           <register> <value>
 NET     "%s" 0x%h                 // NET change           <name> <value>
 DM      0x%h                      // debug mode           <value>


### PR DESCRIPTION
The register numbers for all register types (except CSRs) are specified in decimal, not hex.